### PR TITLE
Item Reward Selection Updates

### DIFF
--- a/args/items.py
+++ b/args/items.py
@@ -82,33 +82,33 @@ def process(args):
 
     args.item_rewards_ids = []
 
-    if args.item_rewards:
-        # Split the comma-separated string
-        for a_item_id in args.item_rewards.split(','):
-            # look for strings first
-            a_item_id = a_item_id.lower().strip()
-            if a_item_id == 'standard':
-                args.item_rewards_ids = [name_id[name] for name in good_items]
-            elif a_item_id == 'premium':
-                args.item_rewards_ids = [name_id[name] for name in better_items]
+    if not args.item_rewards:
+        args.item_rewards = 'standard'
+
+    # Split the comma-separated string
+    for a_item_id in args.item_rewards.split(','):
+        # look for strings first
+        a_item_id = a_item_id.lower().strip()
+        if a_item_id == 'standard':
+            args.item_rewards_ids = [name_id[name] for name in good_items]
+        elif a_item_id == 'premium':
+            args.item_rewards_ids = [name_id[name] for name in better_items]
+        else:
+            item_ids_lower = {k.lower(): v for k, v in name_id.items()}
+            if a_item_id in item_ids_lower:
+                args.item_rewards_ids.append(item_ids_lower[a_item_id])
             else:
-                item_ids_lower = {k.lower(): v for k, v in name_id.items()}
-                if a_item_id in item_ids_lower:
-                    args.item_rewards_ids.append(item_ids_lower[a_item_id])
-                else:
-                    # assuming it's a number... it'll error out if not
-                    args.item_rewards_ids.append(int(a_item_id))
-    else:
-        args.item_rewards_ids = [name_id[name] for name in good_items]
+                # assuming it's a number... it'll error out if not
+                args.item_rewards_ids.append(int(a_item_id))
 
     # remove duplicates and sort
     args.item_rewards_ids = list(set(args.item_rewards_ids))
     args.item_rewards_ids.sort()
 
     # Remove Atma Weapon is it's not Stronger and we're in standard/premium
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids and args.item_rewards:
-        if any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
-            args.item_rewards_ids.remove(name_id["Atma Weapon"])
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
+       and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
+        args.item_rewards_ids.remove(name_id["Atma Weapon"])
 
     # Remove excluded items
     if args.no_free_paladin_shields and name_id["Paladin Shld"] in args.item_rewards_ids:

--- a/args/items.py
+++ b/args/items.py
@@ -98,16 +98,19 @@ def process(args):
                 else:
                     # assuming it's a number... it'll error out if not
                     args.item_rewards_ids.append(int(a_item_id))
-        # remove duplicates and sort
     else:
         args.item_rewards_ids = [name_id[name] for name in good_items]
 
+    # remove duplicates and sort
     args.item_rewards_ids = list(set(args.item_rewards_ids))
     args.item_rewards_ids.sort()
 
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
-            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
-        args.item_rewards_ids.remove(name_id["Atma Weapon"])
+    # Remove Atma Weapon is it's not Stronger and we're in standard/premium
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids and args.item_rewards:
+        if any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
+            args.item_rewards_ids.remove(name_id["Atma Weapon"])
+
+    # Remove excluded items
     if args.no_free_paladin_shields and name_id["Paladin Shld"] in args.item_rewards_ids:
         args.item_rewards_ids.remove(name_id["Paladin Shld"])
     if args.no_exp_eggs and name_id["Exp. Egg"] in args.item_rewards_ids:

--- a/constants/items.py
+++ b/constants/items.py
@@ -3,6 +3,24 @@ EMPTY = 0xff
 
 BREAKABLE_RODS = range(53, 59)
 ELEMENTAL_SHIELDS = range(96, 99)
+DIRKS = range(0, 10)
+SWORDS = range(10, 29)
+LANCES = range(29, 37)
+KNIVES = range(37, 43)
+KATANAS = range(43, 51)
+RODS = range(51, 61)
+BRUSHES = range(61, 65)
+STARS = range(65, 68)
+SPECIAL = range(68, 77)
+GAMBLER = range(77, 83)
+CLAWS = range(83, 90)
+SHIELDS = range(90, 105)
+HELMETS = range(105, 132)
+ARMORS = range(132, 163)
+TOOLS = range(163, 171)
+SKEANS = range(171, 176)
+RELICS = range(176, 231)
+
 
 id_name = {
     0   : "Dirk",

--- a/data/items.py
+++ b/data/items.py
@@ -21,52 +21,7 @@ class Items():
     DESC_START = 0x2d6400
     DESC_END = 0x2d779f
 
-    'process high tier items here'
-    args.item_rewards_ids = []
-
-    if args.item_rewards:
-        # Split the comma-separated string
-        for a_item_id in args.item_rewards.split(','):
-            # look for strings first
-            a_item_id = a_item_id.lower().strip()
-            if a_item_id == 'standard':
-                args.item_rewards_ids = [name_id[name] for name in good_items]
-            elif a_item_id == 'premium':
-                args.item_rewards_ids = [name_id[name] for name in better_items]
-            else:
-                item_ids_lower = {k.lower(): v for k, v in name_id.items()}
-                if a_item_id in item_ids_lower:
-                    args.item_rewards_ids.append(item_ids_lower[a_item_id])
-                else:
-                    # assuming it's a number... it'll error out if not
-                    args.item_rewards_ids.append(int(a_item_id))
-        # remove duplicates and sort
-    else:
-        args.item_rewards_ids = [name_id[name] for name in good_items]
-
-    args.item_rewards_ids = list(set(args.item_rewards_ids))
-    args.item_rewards_ids.sort()
-
     GOOD = args.item_rewards_ids
-
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in GOOD \
-            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard','premium')):
-        GOOD.remove(name_id["Atma Weapon"])
-    if args.no_free_paladin_shields and name_id["Paladin Shld"] in GOOD:
-        GOOD.remove(name_id["Paladin Shld"])
-    if args.no_exp_eggs and name_id["Exp. Egg"] in GOOD:
-        GOOD.remove(name_id["Exp. Egg"])
-    if args.no_illuminas and name_id["Illumina"] in GOOD:
-        GOOD.remove(name_id["Illumina"])
-    if args.no_sprint_shoes and name_id["Sprint Shoes"] in GOOD:
-        GOOD.remove(name_id["Sprint Shoes"])
-    if args.no_moogle_charms and name_id["Moogle Charm"] in GOOD:
-        GOOD.remove(name_id["Moogle Charm"])
-
-    # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
-    # the No Illumina flag is on)
-    if len(GOOD) < 1:
-        GOOD.append(name_id["Empty"])
 
     def __init__(self, rom, args, dialogs, characters):
         self.rom = rom

--- a/data/text/text2.py
+++ b/data/text/text2.py
@@ -27,7 +27,7 @@ text_value = {
               '<dirk icon>'         : 0xd8,
               '<sword icon>'        : 0xd9,
               '<lance icon>'        : 0xda,
-              '<knife icon>'        : 0xdb,
+              '<katana icon>'       : 0xdb,
               '<rod icon>'          : 0xdc,
               '<brush icon>'        : 0xdd,
               '<stars icon>'        : 0xde,

--- a/menus/flags_reward_items.py
+++ b/menus/flags_reward_items.py
@@ -22,10 +22,10 @@ class FlagsRewardItems(scroll_area.ScrollArea):
 
     def _format_items_menu(item_ids):
         from constants.items import id_name
-        COLUMN_WIDTHS = [13, 12]
+        COLUMN_WIDTHS = [13, 13]
         item_lines = []
 
-        # Step through each spell by the number of columns
+        # Step through each item by the number of columns
         for item_idx in range(0, len(item_ids), len(COLUMN_WIDTHS)):
             current_line = ''
             # Populate each column on the line
@@ -37,16 +37,49 @@ class FlagsRewardItems(scroll_area.ScrollArea):
                     padding = COLUMN_WIDTHS[col] - len(item_str)
                     current_line += f"{item_str}{' ' * padding}"
                 else:
-                    # No spell, add padding
+                    # No item, add padding
                     current_line += f"{' ' * COLUMN_WIDTHS[col]}"
             # Write the line
             item_lines.append(current_line)
         return item_lines
 
     def _get_item_icon(item_id):
-        from constants.spells import black_magic_ids, gray_magic_ids, white_magic_ids
+        from constants.items import DIRKS, SWORDS, LANCES, KNIVES, KATANAS, RODS, BRUSHES, \
+            STARS, SPECIAL, GAMBLER, CLAWS, SHIELDS, HELMETS, ARMORS, TOOLS, SKEANS, RELICS
         from data.text.text2 import text_value
         icon = ''
-        # Potentially this could be used to get the appropriate icon for each item type using the same code from
-        # the remove learnable spells menu class
+        if item_id in DIRKS or item_id in KNIVES:
+            icon = chr(text_value['<dirk icon>'])
+        elif item_id in SWORDS:
+            icon = chr(text_value['<sword icon>'])
+        elif item_id in LANCES:
+            icon = chr(text_value['<lance icon>'])
+        elif item_id in KATANAS:
+            icon = chr(text_value['<katana icon>'])
+        elif item_id in RODS:
+            # for some reason, the Rod icon causes submenus to not work
+            icon = ''
+            #icon = chr(text_value['<rod icon'])
+        elif item_id in BRUSHES:
+            icon = chr(text_value['<brush icon>'])
+        elif item_id in STARS:
+            icon = chr(text_value['<stars icon'])
+        elif item_id in SPECIAL:
+            icon = chr(text_value['<special icon>'])
+        elif item_id in GAMBLER:
+            icon = chr(text_value['<gambler icon>'])
+        elif item_id in CLAWS:
+            icon = chr(text_value['<claw icon>'])
+        elif item_id in SHIELDS:
+            icon = chr(text_value['<shield icon>'])
+        elif item_id in HELMETS:
+            icon = chr(text_value['<helmet icon>'])
+        elif item_id in ARMORS:
+            icon = chr(text_value['<armor icon>'])
+        elif item_id in TOOLS:
+            icon = chr(text_value['<tool icon>'])
+        elif item_id in SKEANS:
+            icon = chr(text_value['<skean icon>'])
+        elif item_id in RELICS:
+            icon = chr(text_value['<relic icon>'])
         return icon


### PR DESCRIPTION
**Changes**
- Cleaned up duplicate code
- Added icons to Item Rewards Submenu (except for Rods -- for some reason, that causes the submenu to no longer appear). 
- Fixed bug if flag wasn't specified

**Testing**
- Repeated tests in original PR
- Submenu with `-ir premium`
![image](https://github.com/dbldown11/WorldsCollide/assets/96998881/256ecefe-1ecf-4a2f-88bd-50ea3540a12a)
- Submenu with `-ir 50,69,81,76,89,174,181,165` (to see other icons):
![item_rewards_other_icons](https://github.com/dbldown11/WorldsCollide/assets/96998881/5cf2687a-c05a-4464-b5e8-f87a7a1a0587)
- Tested with `-ir` specified (this caught the bug in the original PR) and confirmed it defaulted to standard
- Tested the High Item Reward Objective in several conditions:
-- `-ir 69 -oe 58.0.0` gave the party a Full Moon, as expected
-- `-ir 26 -nil -oe 58.0.0` gave the party nothing, as expected (since Illumina is excluded)


